### PR TITLE
Fixed wrong node module require

### DIFF
--- a/view/adminhtml/web/ts/babel/plugin-amd-to-magento-amd/ast-utils.js
+++ b/view/adminhtml/web/ts/babel/plugin-amd-to-magento-amd/ast-utils.js
@@ -19,7 +19,7 @@ exports.isVoidExpression = isVoidExpression;
 exports.isInteropRequireCall = isInteropRequireCall;
 exports.isInteropRequireDefinition = isInteropRequireDefinition;
 
-var t = _interopRequireWildcard(require("babel-types"));
+var t = _interopRequireWildcard(require("@babel/types"));
 
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
 

--- a/view/adminhtml/web/ts/babel/plugin-amd-to-magento-amd/index.js
+++ b/view/adminhtml/web/ts/babel/plugin-amd-to-magento-amd/index.js
@@ -13,7 +13,7 @@ exports.default = _default;
 
 var _astUtils = require("./ast-utils");
 
-var t = _interopRequireWildcard(require("babel-types"));
+var t = _interopRequireWildcard(require("@babel/types"));
 
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
 


### PR DESCRIPTION
Fixes error generated when using `npm run ts:build` or `npm run start`.

Error is:
`Error: [BABEL] /var/www/magento/app/code/DaveMacaulay/PageBuilderTypescript/view/adminhtml/web/ts/js/content-type/example-typescript/preview.ts: Cannot find module 'babel-types'`